### PR TITLE
Edits to README to help fix clarity issues for new contributors (Gitlab vs GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
-![logo](https://gitlab.com/flosscoach/flosscoach/raw/master/app/assets/images/flosscoach-logo.png) 
-# FLOSSCoach
+![logo](https://gitlab.com/flosscoach/flosscoach/raw/master/app/assets/images/flosscoach-logo.png)
+
+NOTE: This is a mirrored repository. If you are interested in joining our community, please visit us on [Gitlab](https://gitlab.com/flosscoach/flosscoach/)!
+
+# FLOSScoach
 We are a community aimed to help newcomers get into
 *Free/Libre Open Source Software* (FLOSS). 
 
 ## How to use?
-If you want to use [FLOSScoach](www.flosscoach.com) create an account and join our community! Contact us for help!
+If you want to use [FLOSScoach](https://www.flosscoach.com) create an account and join our community! Contact us for help!
 
 ## Build status
 ![Gitlab pipeline status](https://img.shields.io/gitlab/pipeline/flosscoach/flosscoach.svg)
 
 ## Features
-FLOSSCoach portal has individual project pages, foruns and messages where you can exchange relevant information about OSS with newcomers so they can start contributing
+FLOSScoach portal has individual project pages, forums, and messages where you can exchange relevant information about OSS with newcomers so they can start contributing.
+
 ## Technologies
-FLOSScoach is build using:
+FLOSScoach is built using:
 
 - [Ruby on Rails](https://github.com/rails/rails)
 - [PostgreSQL](https://www.postgresql.org/)
 - [GitLab CI](https://about.gitlab.com/product/continuous-integration/)
 
 ## Code style
-We recommend using [Rails-Style-Guide](https://github.com/rubocop-hq/rails-style-guide) as a coding style
+We recommend using [Rails-Style-Guide](https://github.com/rubocop-hq/rails-style-guide) as a coding style.
 
 ## Contribute
-Want to contribute and not sure how to start? Here's our documentation for [contributions](https://gitlab.com/flosscoach/flosscoach/blob/master/contribute.md)
+Want to contribute and not sure how to start? Here's our documentation for [contributions](https://gitlab.com/flosscoach/flosscoach/blob/master/contribute.md).
 
-We are happy to welcome new contributors.
+If you would like to report an issue, please submit it to our [Gitlab repository](https://gitlab.com/flosscoach/flosscoach/issues). 
+
+We are happy to welcome new contributors! 
 
 


### PR DESCRIPTION
Similar to #8 submitted by @cmatian, I too have made some fixes based on #7. There is some overlap between my commits and @cmatian but I tried to add some additional fixes, so I am sure that most of our changes could be combined.

I apologize for any redundancies I may have caused for creating another PR, but I wanted to be thorough!
 
List of changes: 
1. Added sentence to the very top of the README indicating that the community uses Gitlab.
2. Fixed some hyperlinks were not functional.
3. Edited uppercase consistency of FLOSScoach where it appeared as FLOSSCoach.
4. Other minor grammar errors, consistencies, and punctuation fixes.